### PR TITLE
Docs: Separate SSH instructions into SSH_GUIDE.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,70 +1,171 @@
 <div align="center">
 
-# ☁️ GCP Streamlit Minimal
+# ☁️ GCP Streamlit Minimal (Terraform版)
 
 </div>
 
-GCP Compute EngineでStreamlitアプリケーションを最小構成で実行するためのTerraform設定
+このプロジェクトは、Google Compute Engine (GCE) インスタンス上に最小構成のStreamlitアプリケーションをデプロイするためのTerraform設定を提供します。シンプルで安全、かつモジュール化された出発点となるように設計されています。
 
 ## 📋 概要
 
-- 🖥️ GCP e2-microインスタンスを使用
-- 🐧 Debian 11ベースイメージ
-- 📱 Streamlit最小構成アプリケーション
-- 🌐 標準ポート(8501)でのデプロイ
+-   🖥️ **コンピューティングインスタンス:** デフォルトで`e2-micro` GCEインスタンスをデプロイします。
+-   🐧 **オペレーティングシステム:** Debian 11ベースイメージを使用します。
+-    streamlit **アプリケーション:** タイトルとスライダーを表示する基本的なStreamlitアプリケーションをセットアップします。
+-   🌐 **ネットワーキング:**
+    -   Streamlitアプリケーションをポート8501（設定可能）で公開します。
+    -   StreamlitおよびSSHへのアクセスを許可するファイアウォールルールを設定します。
+    -   **重要なセキュリティノート:** Streamlitファイアウォールルールは、初期状態ではプレースホルダーIPに制限されています。実際のIPアドレスに更新する**必要があります**。
+-   🧱 **モジュール性:** GCEインスタンスの設定にはローカルTerraformモジュールを使用します。
+
+## 📂 プロジェクト構成
+
+```
+.
+├── main.tf                 # ルート設定: プロバイダ、モジュール呼び出し、ファイアウォールルール
+├── variables.tf            # ルート変数: project_id, リージョン, インスタンス設定など
+├── outputs.tf              # ルート出力: streamlit_url, instance_ip
+├── README.md               # このファイル
+└── modules/
+    └── gce_instance/
+        ├── main.tf         # モジュール: GCEインスタンスリソース定義
+        ├── variables.tf    # モジュール: GCEインスタンスの入力変数
+        └── outputs.tf      # モジュール: GCEインスタンスからの出力 (ID, 名前, ネットワーク詳細)
+```
 
 ## 🛠️ 前提条件
 
-- 🔑 Google Cloud Platformアカウント
-- 💰 プロジェクトの作成と課金の有効化
-- ✅ 必要なAPIの有効化:
-  - Compute Engine API
-  - Cloud Resource Manager API
+1.  **Google Cloud Platform (GCP) アカウント:** アクティブなプロジェクトを持つGCPアカウントが必要です。
+2.  **課金の有効化:** GCPプロジェクトで課金が有効になっていることを確認してください。
+3.  **APIの有効化:** GCPプロジェクトで以下のAPIが有効になっている必要があります:
+    *   Compute Engine API
+    *   Cloud Resource Manager API (通常はデフォルトで有効)
+    GCPコンソールまたは`gcloud services enable compute.googleapis.com cloudresourcemanager.googleapis.com`で有効にできます。
+4.  **Terraformのインストール:** [terraform.io](https://www.terraform.io/downloads.html) からTerraformをダウンロードしてインストールします。
+5.  **Google Cloud SDK (`gcloud`) の設定:** `gcloud` CLIをインストールして設定します。以下を実行してGCPで認証します:
+    ```bash
+    gcloud auth application-default login
+    ```
+    これにより、TerraformがGCPアカウントに対して認証できるようになります。
 
-## 🚀 セットアップ
+## ⚙️ 設定
 
-1. terraformの初期化
-```bash
-terraform init
-```
+1.  **リポジトリのクローン (該当する場合):**
+    ```bash
+    # git clone <repository_url>
+    # cd <repository_directory>
+    ```
 
-2. プロジェクトIDの設定
-```bash
-# main.tfのproject値を変更
-provider "google" {
-  project = "your-project-id"  # あなたのプロジェクトIDに変更
-  region  = "asia-northeast1"
-  zone    = "asia-northeast1-a"
-}
-```
+2.  **プロジェクトID:**
+    `variables.tf`を開き、`project_id`のデフォルト値を更新します:
+    ```terraform
+    variable "project_id" {
+      description = "The ID of the GCP project."
+      type        = string
+      default     = "your-project-id" # <-- ここを変更
+    }
+    ```
+    または、`terraform.tfvars`ファイルを作成し（`.gitignore`に`*.tfvars`を追加すればデフォルトでgit管理外になります）、そこにプロジェクトIDを設定します:
+    ```terraform
+    # terraform.tfvars
+    project_id = "your-actual-project-id"
+    ```
+    あるいは、適用時に指定します (機密性の高い値には非推奨):
+    ```bash
+    terraform apply -var="project_id=your-actual-project-id"
+    ```
 
-3. インフラストラクチャのデプロイ
-```bash
-terraform apply
-```
+3.  **重要なセキュリティ: Streamlit用ファイアウォールルールの更新:**
+    `main.tf`を開きます。`allow-streamlit`という名前の`google_compute_firewall`リソースを見つけます。Streamlitアプリケーションにアクセスできるのが自分だけになるように、`source_ranges`をプレースホルダーから実際のIPアドレス/範囲に変更する**必要があります**。
+    ```terraform
+    resource "google_compute_firewall" "streamlit" {
+      # ... 他の設定 ...
+      
+      # 重要: セキュリティのため、これをあなたのIPアドレスに制限してください。
+      # TODO: YOUR_IP_ADDRESS/32 を実際のIPアドレスまたは特定の範囲に置き換えてください。
+      source_ranges = ["YOUR_IP_ADDRESS/32"] # <-- ここを変更 (例: ["1.2.3.4/32"])
+    }
+    ```
+    自分のパブリックIPアドレスを見つけるには、Googleで「what is my IP」と検索してください。
 
-## 📝 使用方法
+4.  **その他の変数:**
+    `variables.tf`を確認し、カスタマイズしたい可能性のある他の設定を確認します:
+    *   `region`, `zone`
+    *   `instance_name`, `machine_type`
+    *   `image`, `disk_size`
+    *   `streamlit_port`, `ssh_port`
 
-デプロイ完了後、出力されるURLにアクセス:
-```
-streamlit_url = http://<external-ip>:8501
-```
+5.  **カスタムサービスアカウント (オプション、セキュリティ強化のため推奨):**
+    GCEインスタンスモジュールは、カスタムサービスアカウントを使用する準備ができています。
+    *   GCPで最小限の必要な権限を持つ専用のサービスアカウントを作成します。
+    *   `main.tf`の`module "gce_instance"`ブロック内で、`service_account_email`パラメータのコメントを解除して設定します:
+        ```terraform
+        module "gce_instance" {
+          source = "./modules/gce_instance"
+          # ... 他のパラメータ ...
+          # セキュリティ強化のため、最小限の権限を持つ専用のサービスアカウントを作成し、
+          # このモジュールブロックの 'service_account_email' 変数経由でそのメールアドレスを提供することを検討してください。
+          # 例: service_account_email = "your-custom-sa@your-project-id.iam.gserviceaccount.com"
+          # service_account_email = "your-custom-sa@your-project-id.iam.gserviceaccount.com"
+        }
+        ```
+    `service_account_email`が提供されないか`null`に設定されている場合、インスタンスは`cloud-platform`スコープを持つデフォルトのCompute Engineサービスアカウントを使用します。
 
-## 🗑️ リソースの削除
+## 🚀 デプロイ
 
-```bash
-terraform destroy
-```
+1.  **Terraformの初期化:**
+    ターミナルでプロジェクトのルートディレクトリに移動し、以下を実行します:
+    ```bash
+    terraform init
+    ```
+    このコマンドは作業ディレクトリを初期化し、必要なプロバイダプラグインをダウンロードします。
+
+2.  **デプロイ計画の作成:**
+    (オプションですが推奨) Terraformが作成/変更するリソースを確認します:
+    ```bash
+    terraform plan
+    ```
+
+3.  **設定の適用:**
+    リソースをデプロイします:
+    ```bash
+    terraform apply
+    ```
+    デプロイを確認するプロンプトが表示されたら`yes`と入力します。
+
+## 🌐 アプリケーションへのアクセス
+
+`terraform apply`が完了すると、TerraformはStreamlitアプリケーションのURLを出力します:
+
+1.  **Streamlit URLの取得:**
+    ```bash
+    terraform output streamlit_url
+    ```
+    `http://<EXTERNAL_IP_ADDRESS>:8501` のような形式になります。
+
+2.  **ブラウザで開く:**
+    このURLをコピーしてウェブブラウザに貼り付けます。アクセスは設定したファイアウォールルールによって制限されていることを忘れないでください。
+
+## 💻 SSHアクセス
+
+GCEインスタンスへのSSHアクセスが可能です。詳細な手順（SSHキーの生成、GCPへの公開鍵の追加、各種SSHクライアントの利用方法を含む）については、[SSH接続ガイド (SSH_GUIDE.md)](./SSH_GUIDE.md) を参照してください。
+
+## 🧹 クリーンアップ
+
+このTerraform設定によって作成されたすべてのリソースを削除するには:
+
+1.  **リソースの破棄:**
+    ```bash
+    terraform destroy
+    ```
+    削除を確認するプロンプトが表示されたら`yes`と入力します。
+
+## 🧱 モジュール
+
+### `gce_instance`
+
+このローカルモジュール (`./modules/gce_instance`) は、Google Compute Engineインスタンスの作成と設定を担当します。様々な入力（インスタンス名、マシンタイプ、イメージ、起動スクリプトなど）を受け取り、作成されたインスタンスに関する詳細を出力します。このモジュラーアプローチはコードの整理に役立ち、必要に応じてGCEインスタンス設定を再利用可能にします。
 
 ## 📜 ライセンス
 
-MITライセンス
-
-## 📚 詳細情報
-
-詳細な説明やチュートリアルは `/docs/learning/` ディレクトリを参照してください:
-
-- 📖 `LEARNING.md`: 実装の詳細な解説
-- 🎓 `CONCEPTS.md`: 使用技術の概念説明
-- ✏️ `EXERCISES.md`: 練習課題
-- 📌 `NOTES.md`: 実装時の注意点
+このプロジェクトはMITライセンスの下でライセンスされています。`LICENSE`ファイル（存在する場合）を参照するか、存在しない場合はMITとみなしてください。
+```

--- a/SSH_GUIDE.md
+++ b/SSH_GUIDE.md
@@ -1,0 +1,67 @@
+## 💻 SSHアクセス
+
+メンテナンスやデバッグのためにCompute EngineインスタンスにSSH接続できます。
+
+1.  **インスタンス詳細の取得:**
+    Terraformの出力からインスタンスの外部IPを取得できます:
+    ```bash
+    terraform output instance_ip
+    ```
+    インスタンス名とゾーンも必要になります。これらは`variables.tf`（または`.tfvars`ファイル）で定義されています。
+
+2.  **`gcloud`を使用した接続 (推奨):**
+    SSH接続する最も簡単な方法は、`gcloud`コマンドラインツールを使用することです。これはSSHキー管理を自動的に処理します:
+    ```bash
+    gcloud compute ssh <YOUR_INSTANCE_NAME> --project <YOUR_PROJECT_ID> --zone <YOUR_INSTANCE_ZONE>
+    ```
+    `<YOUR_INSTANCE_NAME>`、`<YOUR_PROJECT_ID>`、`<YOUR_INSTANCE_ZONE>`を実際の値に置き換えてください。例:
+    ```bash
+    gcloud compute ssh streamlit --project your-project-id --zone asia-northeast1-a
+    ```
+
+3.  **標準SSHクライアントを使用した接続:**
+    必要であれば、標準のSSHクライアントを使用できます。SSH公開鍵がインスタンスに追加されていることを確認する必要があります（gcloudはこれを自動的に行いますが、インスタンスメタデータ経由でSSHキーを管理することもできます）。
+    ```bash
+    ssh -i /path/to/your/private_key your_gcp_user@<INSTANCE_EXTERNAL_IP>
+    ```
+    `/path/to/your/private_key`をSSH秘密鍵へのパスに、`your_gcp_user`をインスタンス上のLinuxユーザー名（多くの場合、`@domain.com`なしのGoogleアカウントユーザー名）に、`<INSTANCE_EXTERNAL_IP>`をIPアドレスに置き換えます。
+
+### 詳細なSSHキー管理 (Manually Managing SSH Keys)
+
+`gcloud compute ssh`コマンドはSSHキーの管理を自動的に行い非常に便利ですが、手動でSSHキーペアを管理し、標準のSSHクライアントで使用することも可能です。以下にその手順を示します。
+
+1.  **SSHキーペアの生成 (Generating SSH Key Pairs):**
+    まず、ローカルマシンでSSHキーペア（秘密鍵と公開鍵）を生成します。ターミナルで以下のコマンドを実行します。
+    ```bash
+    ssh-keygen -t rsa -f ~/.ssh/google_cloud_key -C YOUR_USERNAME
+    ```
+    *   `-t rsa`: RSAタイプのキーを生成します。`ed25519`なども使用可能です (`ssh-keygen -t ed25519 ...`)。
+    *   `-f ~/.ssh/google_cloud_key`: キーファイルのパスと名前を指定します (`~/.ssh/`ディレクトリに`google_cloud_key`という名前で秘密鍵が、`google_cloud_key.pub`という名前で公開鍵が作成されます)。
+    *   `-C YOUR_USERNAME`: キーのコメントです。通常はユーザー名やメールアドレスを使用します (例: `user@example.com`)。
+    コマンド実行中にパスフレーズの入力を求められます。セキュリティ向上のため設定を推奨しますが、省略することも可能です。
+
+2.  **公開鍵のGCPへの追加 (Adding Public Key to GCP):**
+    生成した公開鍵 (`~/.ssh/google_cloud_key.pub`など) の内容をGCPに追加する必要があります。GCPでは、プロジェクト全体または特定のインスタンスに対してSSHキーを登録できます。
+
+    *   **プロジェクト全体のメタデータに追加:**
+        GCPコンソールの「Compute Engine」>「メタデータ」>「SSH認証鍵」タブに公開鍵を追加します。ここに追加された公開鍵は、プロジェクト内のすべてのインスタンス（OS Loginが有効になっていない場合、またはOS Loginでプロジェクト全体の鍵が許可されている場合）で利用可能になります。
+        *   **推奨ケース:** 複数のインスタンスに同じキーでアクセスしたい場合や、新しいインスタンスにも自動的に適用したい場合。
+    *   **特定のインスタンスのメタデータに追加:**
+        特定のGCEインスタンスの詳細ページを開き、「編集」をクリックして「セキュリティとアクセス」セクション内の「SSH認証鍵」に公開鍵を追加します。
+        *   **推奨ケース:** 特定のインスタンスのみにアクセスを制限したい場合。
+
+    公開鍵ファイルの内容全体（例: `ssh-rsa AAAA... YOUR_USERNAME`）をコピーし、GCPコンソールの適切なフィールドに貼り付けます。
+
+3.  **`gcloud compute ssh`コマンドについて (About `gcloud compute ssh` command):**
+    前述の通り、`gcloud compute ssh`コマンドは、多くの場合、ローカルにSSHキーが存在しない場合にキーペアを自動生成し、その公開鍵をGCPプロジェクトのメタデータ（またはOS Loginプロファイル）に登録し、SSH接続までをシームレスに行います。このため、通常は手動でのキー管理は不要です。手動でのキー管理は、この自動処理を理解したい場合、特定の既存キーペアを使用したい場合、または`gcloud`ツールが利用できない環境で作業する場合に役立ちます。
+
+4.  **標準SSHクライアントの使用 (Using a Standard SSH Client):**
+    公開鍵をGCPに登録し、インスタンスが起動したら、指定した秘密鍵を使って標準のSSHクライアントで接続できます。
+    ```bash
+    ssh -i ~/.ssh/google_cloud_key YOUR_USERNAME@INSTANCE_EXTERNAL_IP
+    ```
+    *   `~/.ssh/google_cloud_key`: 手順1で生成した秘密鍵のパス。
+    *   `YOUR_USERNAME`: インスタンスにログインするユーザー名。これは通常、公開鍵のコメント部分 (`-C`で指定したユーザー名) と一致しますが、OS Loginを使用している場合はGCPアカウントに基づいたユーザー名 (例: `firstname_lastname_example_com`) になることがあります。
+    *   `INSTANCE_EXTERNAL_IP`: 接続するインスタンスの外部IPアドレス。
+
+この手動でのキー管理方法は、`gcloud`コマンドが利用できない環境や、特定のセキュリティポリシーに従う必要がある場合に特に有効です。

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -1,0 +1,39 @@
+# Terraform Variables Example File
+# This file provides examples of variables that can be set for the Terraform configuration.
+# Uncomment and modify the lines as needed. For sensitive values, ensure you use appropriate placeholders or manage them securely.
+
+# Description: The ID of the GCP project.
+# default     = "your-project-id"
+# project_id  = "your-project-id"
+
+# Description: The region for GCP resources.
+# default     = "asia-northeast1"
+# region      = "asia-northeast1"
+
+# Description: The zone for GCP resources.
+# default     = "asia-northeast1-a"
+# zone        = "asia-northeast1-a"
+
+# Description: The name of the Compute Engine instance.
+# default     = "streamlit"
+# instance_name = "streamlit"
+
+# Description: The machine type for the Compute Engine instance.
+# default     = "e2-micro"
+# machine_type = "e2-micro"
+
+# Description: The image for the Compute Engine instance's boot disk.
+# default     = "debian-cloud/debian-11"
+# image       = "debian-cloud/debian-11"
+
+# Description: The size of the boot disk in GB.
+# default     = 10
+# disk_size   = 10
+
+# Description: The port for the Streamlit application.
+# default     = 8501
+# streamlit_port = 8501
+
+# Description: The port for SSH access.
+# default     = 22
+# ssh_port    = 22


### PR DESCRIPTION
- I will create a new `SSH_GUIDE.md` file containing detailed instructions for SSH key generation and connection methods in Japanese.
- I will update the main `README.md` (Japanese) to remove the detailed SSH section and link to the new `SSH_GUIDE.md`.
- This addresses your feedback to make the main README more concise and provide a dedicated file for SSH details.